### PR TITLE
Adiciona estilo em projeto Katz com radios Bootstrap

### DIFF
--- a/javascript_dom/projetos/07_katz/script.js
+++ b/javascript_dom/projetos/07_katz/script.js
@@ -43,15 +43,11 @@ btnStart.addEventListener("click", () => {
             .map(
               (item, index) => `
             <div class="mb-4">
-              <label class="form-label"><strong>${item.pergunta}</strong></label><br>
-              <div class="form-check">
-                <input class="form-check-input" type="radio" name="p${index}" value="1" required>
-                <label class="form-check-label">${item.resposta_1}</label>
-              </div>
-              <div class="form-check">
-                <input class="form-check-input" type="radio" name="p${index}" value="0">
-                <label class="form-check-label">${item.resposta_2}</label>
-              </div>
+              <p class="fw-semibold mb-2">${item.pergunta}</p>
+              <input class="btn-check" type="radio" name="p${index}" id="p${index}-1" value="1" autocomplete="off" required>
+              <label class="btn btn-outline-primary w-100 mb-2" for="p${index}-1">${item.resposta_1}</label><br>
+              <input class="btn-check" type="radio" name="p${index}" id="p${index}-2" value="0" autocomplete="off">
+              <label class="btn btn-outline-primary w-100" for="p${index}-2">${item.resposta_2}</label>
             </div>
           `
             )

--- a/javascript_dom/projetos/07_katz/style.css
+++ b/javascript_dom/projetos/07_katz/style.css
@@ -5,3 +5,14 @@ body {
 #div-respostas .card {
   margin-bottom: 1rem;
 }
+
+.btn-outline-primary {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.btn-check:checked + .btn-outline-primary {
+  color: #fff;
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+}


### PR DESCRIPTION
## Summary
- estiliza as opcoes da Escala de Katz como botoes usando Bootstrap
- ajusta CSS para largura total e cor ao selecionar

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68533ae2ea5c83329bd0e39e6057e946